### PR TITLE
No longer require f41 for Rust libraries

### DIFF
--- a/.github/ISSUE_TEMPLATE/rust-library-release.md
+++ b/.github/ISSUE_TEMPLATE/rust-library-release.md
@@ -17,4 +17,3 @@ Prior release:
     - [ ] verify stratisd scratch build succeeds in rawhide w/ new version:
   - [ ] f43:
   - [ ] f42: 
-  - [ ] f41:


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/805